### PR TITLE
UPDATE: FACEBOOK LINK, ROBOTS.TXT SITEMAP CACHE

### DIFF
--- a/gridsome.config.js
+++ b/gridsome.config.js
@@ -12,6 +12,7 @@ module.exports = {
   },
   siteUrl: (process.env.SITE_URL ? process.env.SITE_URL : 'https://itcracy.com'),
   settings: {
+    facebook: process.env.URL_FACEBOOK || 'https://www.facebook.com/ITcracy-106034727773892/',
     instagram: process.env.URL_INSTAGRAM || 'https://www.instagram.com/itcracy',
     gitlab : process.env.URL_GITLAB || 'https://gitlab.com/itcracy',
     github: process.env.URL_GITHUB || 'https://github.com/ITcracy',
@@ -91,8 +92,15 @@ module.exports = {
     {
       use: '@gridsome/plugin-sitemap',
       options: {
+          cacheTime: 3600,
       }
+  },
+  {
+      use: 'gridsome-plugin-robots',
+      options: {
+        policy: [{ userAgent: '*', allow: '/' }]
     }
+}
 
   ]
 }

--- a/package.json
+++ b/package.json
@@ -10,9 +10,10 @@
     "gridsome": "^0.7.0"
   },
   "devDependencies": {
+    "gridsome-plugin-robots": "^0.2.1",
+    "@gridsome/plugin-sitemap": "^0.2.3",
     "gridsome-plugin-gtm": "^0.1.1",
     "@gridsome/plugin-google-analytics": "^0.1.0",
-    "@gridsome/plugin-sitemap": "^0.2.3",
     "@gridsome/remark-prismjs": "^0.3.0",
     "@gridsome/source-filesystem": "^0.6.2",
     "@gridsome/transformer-remark": "^0.5.0",

--- a/src/components/LayoutHeader.vue
+++ b/src/components/LayoutHeader.vue
@@ -41,6 +41,9 @@
           <a v-if="settings.gitlab" :href="settings.gitlab" class="sm:ml-3" target="_blank" rel="noopener noreferrer" title="Gitlab" name="Gitlab">
             <GitlabIcon size="1.5x" />
           </a>
+          <a v-if="settings.facebook" :href="settings.facebook" class="sm:ml-3" target="_blank" rel="noopener noreferrer" title="Facebook" name="Facebook">
+            <FacebookIcon size="1.5x" />
+          </a>
           <a v-if="settings.instagram" :href="settings.instagram" class="sm:ml-3" target="_blank" rel="noopener noreferrer" title="Instagram" name="Instagram">
             <InstagramIcon size="1.5x" />
           </a>
@@ -65,6 +68,7 @@ query {
     settings {
       github
       gitlab
+      facebook
       instagram
       nav {
         links {
@@ -80,7 +84,7 @@ query {
 <script>
 import ToggleDarkMode from "@/components/ToggleDarkMode";
 import Logo from '@/components/Logo';
-import { SunIcon, MoonIcon, GithubIcon, GitlabIcon, InstagramIcon } from "vue-feather-icons";
+import { SunIcon, MoonIcon, GithubIcon, GitlabIcon, FacebookIcon, InstagramIcon } from "vue-feather-icons";
 
 const Search = () => import(/* webpackChunkName: "search" */ "@/components/Search").catch(error => console.warn(error));
 
@@ -93,6 +97,7 @@ export default {
     MoonIcon,
     GithubIcon,
     GitlabIcon,
+    FacebookIcon,
     InstagramIcon,
 
   },


### PR DESCRIPTION
- Adds facebook link to the website.
- Changes the sitemap cache to 3600sec.
- Adds robots.txt to website.

Signed-off by: Ishan Masdekar <imasdekar@disroot.org>